### PR TITLE
Fix missing icons and logo issue (#4)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MCP Landscape - Your #1 Community Platform for discovering MCP</title>
+    
+    <!-- Favicon and icon meta tags -->
+    <link rel="icon" type="image/svg+xml" href="images/mcp-landscape-logo.svg">
+    <link rel="apple-touch-icon" href="images/mcp-landscape-logo.svg">
+    <meta name="theme-color" content="#3B82F6">
+    
+    <!-- Social media meta tags -->
+    <meta property="og:title" content="MCP Landscape - Your #1 Community Platform for discovering MCP">
+    <meta property="og:description" content="Discover the most comprehensive curated list of MCP Servers, Clients, and Toolkits">
+    <meta property="og:image" content="https://mcp.collabnix.com/images/mcp-landscape-logo.svg">
+    <meta property="og:url" content="https://mcp.collabnix.com">
+    <meta name="twitter:card" content="summary_large_image">
+    
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css">
@@ -14,7 +27,7 @@
             <nav class="navbar">
                 <div class="logo">
                     <a href="index.html">
-                        <img src="images/mcp-landscape-logo.png" alt="MCP Landscape Logo" onerror="this.src='https://via.placeholder.com/200x50?text=MCP+Landscape'">
+                        <img src="images/mcp-landscape-logo.svg" alt="MCP Landscape Logo" onerror="this.src='https://via.placeholder.com/200x50?text=MCP+Landscape'">
                     </a>
                 </div>
                 <ul class="nav-links">
@@ -66,7 +79,7 @@
                     Model Context Protocol (MCP) is an open protocol that enables AI models to securely interact with local and remote resources through standardized server implementations. MCP servers extend AI capabilities through file access, database connections, API integrations, and other contextual services.
                 </p>
                 <div class="mcp-diagram">
-                    <img src="images/mcp-diagram.png" alt="MCP Diagram" onerror="this.src='https://via.placeholder.com/800x400?text=MCP+Diagram'">
+                    <img src="images/mcp-diagram.svg" alt="MCP Diagram" onerror="this.src='https://via.placeholder.com/800x400?text=MCP+Diagram'">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Changed image references from .png to .svg to match actual file extensions
- Fixed logo reference: mcp-landscape-logo.png → mcp-landscape-logo.svg
- Fixed diagram reference: mcp-diagram.png → mcp-diagram.svg
- Added proper favicon and icon meta tags for better browser support
- Added Open Graph and Twitter Card meta tags for social media sharing
- Added theme-color meta tag for better mobile experience

This resolves the missing logos and icons issue reported in #4.