### PR TITLE
Fix missing logos Fix missing logo issues: Add CircleCI and MCP Server icons

### DIFF
--- a/icons/common/server.svg
+++ b/icons/common/server.svg
@@ -1,0 +1,14 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="4" width="20" height="4" rx="1" fill="#4A90E2" stroke="#357ABD" stroke-width="1"/>
+  <rect x="2" y="10" width="20" height="4" rx="1" fill="#4A90E2" stroke="#357ABD" stroke-width="1"/>
+  <rect x="2" y="16" width="20" height="4" rx="1" fill="#4A90E2" stroke="#357ABD" stroke-width="1"/>
+  <circle cx="5" cy="6" r="1" fill="white"/>
+  <circle cx="8" cy="6" r="1" fill="white"/>
+  <circle cx="5" cy="12" r="1" fill="white"/>
+  <circle cx="8" cy="12" r="1" fill="white"/>
+  <circle cx="5" cy="18" r="1" fill="white"/>
+  <circle cx="8" cy="18" r="1" fill="white"/>
+  <rect x="11" y="5" width="8" height="2" rx="0.5" fill="white" opacity="0.7"/>
+  <rect x="11" y="11" width="8" height="2" rx="0.5" fill="white" opacity="0.7"/>
+  <rect x="11" y="17" width="8" height="2" rx="0.5" fill="white" opacity="0.7"/>
+</svg>

--- a/icons/devops/circleci.svg
+++ b/icons/devops/circleci.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" stroke="#343434" stroke-width="2" fill="none"/>
+  <circle cx="12" cy="12" r="6" fill="#343434"/>
+  <circle cx="12" cy="12" r="3" fill="white"/>
+  <path d="M12 2a10 10 0 0 1 7.07 2.93l-2.12 2.12A6.5 6.5 0 0 0 12 5.5" stroke="#00D924" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M12 18.5a6.5 6.5 0 0 1-4.95-2.29l-2.12 2.12A10 10 0 0 0 12 22" stroke="#00D924" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## 🎯 Problem Solved
Fixed missing logo issues on the MCP Landscape website (mcp.collabnix.com) where CircleCI and MCP Server were showing placeholder question mark icons.

## ✅ Changes Made
- **Added CircleCI Icon**: `icons/devops/circleci.svg`
- **Added MCP Server Icon**: `icons/common/server.svg`

Both icons follow repository standards (24x24 SVG, proper colors, clean design).

## 🚀 Impact
- Eliminates placeholder icons on MCP Landscape website
- Improves visual consistency and professional appearance
- Ready for immediate deployment