### PR TITLE
docs: add Nutrient DWS MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ MCP servers for accessing external services and APIs.
 | 11 | resend | Email delivery and management service | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/resend.md) |
 | 12 | **x402engine-mcp** | 51 pay-per-call APIs for AI agents — LLMs, image/video generation, code execution, TTS, transcription, crypto data, wallet analytics, web scraping, and IPFS via HTTP 402 micropayments | TBD | [GitHub](https://github.com/agentc22/x402engine-mcp) |
 | 13 | **mcp-api-bridge-lite** | Free REST API to MCP bridge — connect any REST API to AI assistants with simple YAML configuration, supporting GET, POST, PUT, DELETE with authentication | TBD | [GitHub](https://github.com/tiranmoskovitch-dev/mcp-api-bridge-lite) |
+| 14 | nutrient-dws-mcp-server | MCP server for Nutrient Document Web Services API (convert, merge, redact, sign, OCR, watermark, extract) | TBD | [GitHub](https://github.com/PSPDFKit/nutrient-dws-mcp-server) |
 
 ### AI & Machine Learning
 


### PR DESCRIPTION
Adds **Nutrient DWS MCP Server** to the **Integrations & APIs** table.

- Repo: https://github.com/PSPDFKit/nutrient-dws-mcp-server
- Capability summary: document processing tools for convert, merge, redact, sign, OCR, watermark, and extraction workflows.

Happy to add nutrient-document-engine-mcp-server in a follow-up PR if that fits your category structure better.
