### PR TITLE
Add MCP Trust Kit to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ MCP servers for AI and machine learning capabilities.
 | 5 | portel-dev/ncp | TypeScript | MCP orchestrator with intelligent discovery, 98.2% accuracy, and 94.8% token savings. Transforms 100+ tools into 2 unified interfaces |
 | 6 | strowk/mcp-autotest | Go | YAML-based autotest tool |
 | 7 | khalidsaidi/ragmap | TypeScript | RAG-focused MCP subregistry + discovery server: semantic/keyword search, filters (transport, hasRemote, reachable), MCP tools for finding retrieval-capable servers. [GitHub](https://github.com/khalidsaidi/ragmap) · [API](https://ragmap-api.web.app) |
+| 8 | [MCP Trust Kit](https://github.com/aak204/MCP-Trust-Kit) | Python | Deterministic CI scanner and surface-risk scoring for MCP servers. |
 
 ### Hosting Solutions
 


### PR DESCRIPTION
Hi!

I'd like to suggest adding **MCP Trust Kit** to your awesome list.

It's an open-source, deterministic CI scanner that evaluates the surface risk (blast radius) of MCP servers before they are deployed to production. It checks for schema hygiene and flags dangerous capabilities (like filesystem mutation or shell execution).

-   Repo: https://github.com/aak204/MCP-Trust-Kit

Thank you for maintaining this valuable resource for the MCP community!