### PR TITLE
Add ToolRouter — unified gateway to 150+ MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ MCP servers for AI and machine learning capabilities.
 |---|-----------|-------------|
 | 1 | Glama | Platform for hosting open-source MCP servers |
 | 2 | Smithery | Cloud hosting for MCP servers via containers |
+| 3 | [ToolRouter](https://toolrouter.com) | Give your AI agent superpowers with access to 150+ tools on demand with just one account. Competitor research, video production, web search, image generation, security scanning, and more. One API key replaces managing dozens of provider accounts. `npx -y toolrouter-mcp` |
 
 ### Templates
 


### PR DESCRIPTION
Adds ToolRouter to the list — a unified MCP gateway giving agents access to 150+ tools through one connection. One API key replaces managing dozens of separate provider accounts. Growing daily.

- Website: https://toolrouter.com
- npm: https://www.npmjs.com/package/toolrouter-mcp
- Remote MCP: https://api.toolrouter.com/mcp