### PR TITLE
Add MRC Data to Integrations & APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ MCP servers for accessing external services and APIs.
 | 19 | **nutrient-dws-mcp-server** | MCP server for Nutrient Document Web Services API — convert, merge, redact, sign, OCR, watermark, and extract documents | TBD | [GitHub](https://github.com/PSPDFKit/nutrient-dws-mcp-server) |
 | 20 | **n8n-mcp-server** | MCP server for interacting with the n8n workflow automation API | TBD | [GitHub](https://github.com/leonardsellem/n8n-mcp-server) |
 | 21 | **Gmail-MCP-Server** | MCP server for Gmail integration — read, search, send, and manage emails in Claude Desktop | TBD | [GitHub](https://github.com/jasonsum/Gmail-MCP-Server) |
+| 22 | **MRC Data** | China's apparel supply chain data infrastructure for AI agents — 1,040+ suppliers, 351 lab-tested fabrics, 173 industrial clusters with AATCC / ISO / GB lab test data | TBD | [GitHub](https://github.com/meacheal-ai/mrc-data) |
 
 ### AI & Machine Learning
 


### PR DESCRIPTION
## Summary

Add MRC Data to the Integrations & APIs section.

MRC Data is China's apparel supply chain data infrastructure for AI agents. It provides 10 MCP tools covering 1,040+ verified Chinese suppliers, 351 lab-tested fabrics, and 173 industrial clusters. Every record is enriched with AATCC / ISO / GB lab test data.

- **GitHub:** https://github.com/meacheal-ai/mrc-data
- **MCP Endpoint:** https://api.meacheal.ai/mcp (HTTP transport, Bearer auth)
- **Docs:** https://api.meacheal.ai/docs
- **Demo:** https://api.meacheal.ai/demo