### PR TITLE
Add EnigmAgent to Security & Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ There are currently 109 MCP servers available:
 | 12 | **osaurus** | Own your AI. The native macOS harness for AI agents -- any model, persistent memory, autonomous execution, cryptographic identity. Built in Swift. Fully offline. Open source. | TBD | [GitHub](https://github.com/osaurus-ai/osaurus) |
 | 13 | **ENScan_GO** | 一款基于各大企业信息API的工具，解决在遇到的各种针对国内企业信息收集难题。一键收集控股公司ICP备案、APP、小程序、微信公众号等信息聚合导出。支持MCP接入 | TBD | [GitHub](https://github.com/wgpsec/ENScan_GO) |
 | 14 | **Gmail-MCP-Server** | A Model Context Protocol (MCP) server for Gmail integration in Claude Desktop with auto authentication support. This server enables AI assistants to manage Gmail through natural language interactions. | TBD | [GitHub](https://github.com/GongRzhe/Gmail-MCP-Server) |
+| 16 | **EnigmAgent** | AES-256-GCM + Argon2id encrypted vault. Resolves  API keys at runtime — keys never appear in prompts or logs | TBD | [GitHub](https://github.com/Agnuxo1/EnigmAgent) |
 
 ### Development Tools
 


### PR DESCRIPTION
Adds EnigmAgent to the Security & Authentication section.

**EnigmAgent** — AES-256-GCM + Argon2id encrypted local vault MCP server. Resolves `{{PLACEHOLDER}}` API keys at runtime so secrets never appear in prompts or logs.

GitHub: https://github.com/Agnuxo1/EnigmAgent