### PR TITLE
feat: add kc-agent (KubeStellar Console) to DevOps & Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ MCP servers for managing infrastructure, containers, and DevOps workflows.
 | 33 | **kubernetes-mcp-server** | Model Context Protocol (MCP) server for Kubernetes and OpenShift | TBD | [GitHub](https://github.com/containers/kubernetes-mcp-server) |
 | 34 | **terraform-mcp-server** | The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development. | TBD | [GitHub](https://github.com/hashicorp/terraform-mcp-server) |
 | 35 | **awesome-devops-mcp-servers** | A curated list of awesome MCP servers focused on DevOps tools and capabilities. | TBD | [GitHub](https://github.com/rohitg00/awesome-devops-mcp-servers) |
+| 36 | **kc-agent (KubeStellar Console)** | MCP server exposing multi-cluster Kubernetes resources — pods, deployments, services, nodes, and events — across all kubeconfig contexts via a single WebSocket endpoint. Part of KubeStellar Console, an AI-powered multi-cluster Kubernetes dashboard. | TBD | [GitHub](https://github.com/kubestellar/console) |
 
 ### Database & Storage
 


### PR DESCRIPTION
## Summary

Adds **kc-agent** (KubeStellar Console) to the **DevOps & Infrastructure** section as a containerized MCP server for multi-cluster Kubernetes management.

## What is kc-agent?

**kc-agent** is the local agent component of [KubeStellar Console](https://github.com/kubestellar/console) — an open-source, AI-powered multi-cluster Kubernetes dashboard.

- 🔌 **MCP server** that exposes multi-cluster Kubernetes resources to AI agents (Claude Desktop, Cursor, Windsurf, etc.)
- 🌐 **Multi-cluster**: reads all kubeconfig contexts and provides a unified view across clusters
- 📦 **Resources exposed**: pods, deployments, services, nodes, events, namespaces
- 🔗 **Single WebSocket endpoint** for all clusters via `ws://localhost:8585/ws`
- 🚀 **Install**: `curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash`
- 💻 **Demo**: https://console.kubestellar.io

## Why this fits the DevOps & Infrastructure section

kc-agent joins existing Kubernetes MCP servers in this section (mcp-server-kubernetes, kubectl-mcp-server, kubernetes-mcp-server) but adds:
- Multi-cluster federation support (KubeStellar multi-cluster architecture)
- AI-guided installation missions for 250+ CNCF projects
- WebSocket-based MCP bridge for remote cluster access