### PR TITLE
Add Packrift MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ MCP servers for accessing external services and APIs.
 |---|------------|-------------|------------------|------|
 | 1 | stripe | Process payments and manage financial transactions | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/stripe.md) |
 | 2 | shopify | Manage Shopify e-commerce stores and products | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/shopify.md) |
+| 3 | **Packrift MCP** | Remote MCP server for packaging supplies: product search, live pricing, inventory, package-fit recommendations, shipping estimates, and cart URLs | TBD | [GitHub](https://github.com/Packrift/packrift-mcp) |
 | 3 | **shopsavvy** | Complete product and pricing data solution - search products, compare prices, track history | TBD | [GitHub](https://github.com/shopsavvy/shopsavvy-mcp-server) |
 | 4 | **agent-signal** | Collective intelligence for AI shopping agents - 23 tools for buyer intelligence, seller analytics, price alerts, and trend tracking | TBD | [GitHub](https://github.com/dan24ou-cpu/agent-signal) |
 | 5 | atlassian | Integrate with Atlassian products like Jira and Confluence | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/atlassian.md) |


### PR DESCRIPTION
Adds Packrift MCP to the Integrations & APIs section. Packrift MCP is a public remote MCP server for packaging supplies, with product search, live pricing, inventory, package-fit recommendations, shipping estimates, and cart URL tools.