### PR TITLE
Add Sanka MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ MCP servers for accessing external services and APIs.
 | 20 | **n8n-mcp-server** | MCP server for interacting with the n8n workflow automation API | TBD | [GitHub](https://github.com/leonardsellem/n8n-mcp-server) |
 | 21 | **Gmail-MCP-Server** | MCP server for Gmail integration — read, search, send, and manage emails in Claude Desktop | TBD | [GitHub](https://github.com/jasonsum/Gmail-MCP-Server) |
 | 22 | **short-video-maker** | Creates short videos for TikTok, Instagram Reels, and YouTube Shorts using the Model Context Protocol (MCP) and a REST API. | TBD | [GitHub](https://github.com/gyoridavid/short-video-maker) |
+| 23 | **Sanka MCP Server** | Hosted remote MCP server for Sanka API, connecting AI agents to CRM and back-office workflows. | TBD | [GitHub](https://github.com/sankaHQ/sanka-mcp) |
 | 24 | **mcp-notion-server** | A Model Context Protocol server for connecting Notion to MCP-compatible clients | TBD | [GitHub](https://github.com/suekou/mcp-notion-server) |
 
 ### AI & Machine Learning


### PR DESCRIPTION
## Summary
- Add Sanka MCP Server to the curated MCP server list
- Link to the public repository: https://github.com/sankaHQ/sanka-mcp

## Notes
- Sanka MCP is a hosted remote MCP server for Sanka API, connecting AI agents to CRM and back-office workflows.
- Documentation and hosted endpoint information are available in the public repository README.

## Verification
- Checked for an existing Sanka entry before adding this one.
- Ran `git diff --check` locally for this README-only change.
