### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ MCP servers for accessing external services and APIs.
 | 16 | **agent-signal** | Collective intelligence for AI shopping agents — buyer intelligence, seller analytics, price alerts, and session logging | TBD | [GitHub](https://github.com/dan24ou-cpu/agent-signal) |
 | 17 | **dexpaprika-mcp** | Real-time DEX data across multiple blockchains with pool, token, OHLCV, and trade data. Free, no API key | TBD | [GitHub](https://github.com/coinpaprika/dexpaprika-mcp) |
 | 18 | **coinpaprika-mcp** | Crypto market data for thousands of coins and exchanges — tickers, OHLCV, historical prices. Free, no API key | TBD | [GitHub](https://github.com/coinpaprika/coinpaprika-mcp) |
-| 19 | **TWZRD Agent Intel** | Solana-native trust scoring and x402 payment receipt MCP server for AI agents — free preflight, paid signed V5 trust receipt. Streamable-HTTP transport | TBD | [GitHub](https://github.com/twzrd-sol/wzrd-final) |
+| 19 | **TWZRD Agent Intel** | Solana-native trust scoring and x402 payment receipt MCP server for AI agents — free preflight, paid signed V5 trust receipt. Streamable-HTTP transport | TBD | [GitHub](https://intel.twzrd.xyz) |
 | 19 | **nutrient-dws-mcp-server** | MCP server for Nutrient Document Web Services API — convert, merge, redact, sign, OCR, watermark, and extract documents | TBD | [GitHub](https://github.com/PSPDFKit/nutrient-dws-mcp-server) |
 | 20 | **n8n-mcp-server** | MCP server for interacting with the n8n workflow automation API | TBD | [GitHub](https://github.com/leonardsellem/n8n-mcp-server) |
 | 21 | **Gmail-MCP-Server** | MCP server for Gmail integration — read, search, send, and manage emails in Claude Desktop | TBD | [GitHub](https://github.com/jasonsum/Gmail-MCP-Server) |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ MCP servers for accessing external services and APIs.
 | 16 | **agent-signal** | Collective intelligence for AI shopping agents — buyer intelligence, seller analytics, price alerts, and session logging | TBD | [GitHub](https://github.com/dan24ou-cpu/agent-signal) |
 | 17 | **dexpaprika-mcp** | Real-time DEX data across multiple blockchains with pool, token, OHLCV, and trade data. Free, no API key | TBD | [GitHub](https://github.com/coinpaprika/dexpaprika-mcp) |
 | 18 | **coinpaprika-mcp** | Crypto market data for thousands of coins and exchanges — tickers, OHLCV, historical prices. Free, no API key | TBD | [GitHub](https://github.com/coinpaprika/coinpaprika-mcp) |
+| 19 | **TWZRD Agent Intel** | Solana-native trust scoring and x402 payment receipt MCP server for AI agents — free preflight, paid signed V5 trust receipt. Streamable-HTTP transport | TBD | [GitHub](https://github.com/twzrd-sol/wzrd-final) |
 | 19 | **nutrient-dws-mcp-server** | MCP server for Nutrient Document Web Services API — convert, merge, redact, sign, OCR, watermark, and extract documents | TBD | [GitHub](https://github.com/PSPDFKit/nutrient-dws-mcp-server) |
 | 20 | **n8n-mcp-server** | MCP server for interacting with the n8n workflow automation API | TBD | [GitHub](https://github.com/leonardsellem/n8n-mcp-server) |
 | 21 | **Gmail-MCP-Server** | MCP server for Gmail integration — read, search, send, and manage emails in Claude Desktop | TBD | [GitHub](https://github.com/jasonsum/Gmail-MCP-Server) |


### PR DESCRIPTION
TWZRD Agent Intel is a Solana-native MCP server providing trust scoring and x402 payment receipt generation for AI agents.

- **MCP endpoint**: https://intel.twzrd.xyz/mcp (Streamable-HTTP)
- **GitHub**: https://intel.twzrd.xyz
- **Transport**: Streamable-HTTP

Added to the **Integrations & APIs** section alongside x402engine-mcp, dexpaprika-mcp, and solana-agent-kit — it fits naturally in the crypto/payments cluster.

Free preflight checks let agents verify trust before paying; paid endpoint returns a signed V5 trust receipt backed by on-chain Solana history.