### PR TITLE
Add Xquik MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ MCP servers for web search, content access, and web automation.
 | 26 | **duckduckgo-mcp-server** | A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing. | TBD | [GitHub](https://github.com/nickclyde/duckduckgo-mcp-server) |
 | 27 | **browser-use-mcp-server** | Browse the web, directly from Cursor etc. | TBD | [GitHub](https://github.com/kontext-security/browser-use-mcp-server) |
 | 28 | **openagent** | ⚡️next-generation personal AI assistant powered by LLM, RAG and agent loops, supporting computer-use, browser-use and coding agent, demo: https://demo.openagentai.org | TBD | [GitHub](https://github.com/the-open-agent/openagent) |
+| 29 | **Xquik MCP Server** | X/Twitter data extraction, account monitoring, webhooks, and API exploration via MCP | TBD | [GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
 
 ### Integrations & APIs
 


### PR DESCRIPTION
## Summary

Adds Xquik MCP Server to the Web & Content MCP server table.

## Validation

- Checked the target README and repository tree for existing Xquik entries.
- Checked all-state target PRs and issues for Xquik duplicates.
- Verified the Xquik repository and public docs links return HTTP 200.
- Ran `git diff --check`.
- Scanned the added line for public-safety issues and unsupported claims.

Live API-key smoke testing was not run because the remote MCP endpoint requires authentication.
