### PR TITLE
Add Helium MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A comprehensive curated list of containerised MCP Servers, Clients and toolkits.
   - [Templates](#templates)
 
 ## Containerised MCP Servers
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) — Real-time news with 37-dimension bias scoring, ML options pricing, and live market data. [Interactive demo](https://connerlambden.github.io/helium-news-explorer/) · [REST API](https://heliumtrades.com/mcp-page/)
 
 ### DevOps & Infrastructure
 


### PR DESCRIPTION
Adds Helium MCP — 37-dim news bias scoring across 216 sources, ML options pricing, live market data. Interactive demos: https://connerlambden.github.io/helium-news-explorer/