### PR TITLE
feat: add NotFair — Claude Code skills for SEO & paid ads (Google Ads MCP, Meta Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ MCP servers for AI and machine learning capabilities.
 | 62 | **google-meta-ads-ga4-mcp** | MCP server for Google Ads, Meta Ads & GA4 — works with ChatGPT, Claude, Cursor, n8n, Windsurf & more. 250+ tools for campaign management, analytics & optimization. | TBD | [GitHub](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp) |
 | 63 | **cocos-mcp-server** | 一款全面的、便捷的cocos creator AI MCP服务插件，适用于3.8.0以上cocos版本，一键安装，一键启动。A comprehensive and convenient cocos creator AI MCP service plug-in, suitable for cocos versions above 3.8.0, one-click installation and one-click start. | TBD | [GitHub](https://github.com/DaxianLee/cocos-mcp-server) |
 | 64 | **RunAPI** | MCP server for model discovery and AI image, video, music/audio, text-to-speech, and LLM jobs via RunAPI | TBD | [GitHub](https://github.com/runapi-ai/mcp) |
+| 65 | **NotFair** | Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads — connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP | TBD | [GitHub](https://github.com/nowork-studio/NotFair) |
 
 ## MCP Clients
 


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** to the AI & Machine Learning section. It's an open-source set of Claude Code agent skills for marketing work — covering SEO/GEO analysis, keyword research, schema markup, Google Ads audits, and Meta Ads management. It connects to live ad and analytics data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

It has ~2.9k stars, is MIT-licensed, and feels like a natural addition alongside the other MCP-connected AI tools already listed here.

Happy to reword the description, move it to a different section, or trim anything that doesn't fit — whatever works best for you.