### PR TITLE
Add screenpipe to Knowledge Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ There are currently 109 MCP servers available:
 | 3 | context7 | Provide contextual information for enhanced AI conversations | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/context7.md) |
 | 4 | atlas-docs | Access MongoDB Atlas documentation and best practices | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/atlas-docs.md) |
 | 5 | **knowledge-rag** | Local RAG system via MCP — hybrid search (semantic + BM25 + RRF), cross-encoder reranking, markdown-aware chunking, 12 MCP tools. Zero external servers | TBD | [GitHub](https://github.com/lyonzin/knowledge-rag) |
+| 6 | **screenpipe** | 24/7 local screen and mic recording; MCP server indexes OCR, accessibility, and audio transcripts so agents can search what you've seen, said, or heard. Works with Ollama. | TBD | [GitHub](https://github.com/screenpipe/screenpipe) |
 
 ### Multimedia & Design
 


### PR DESCRIPTION
Adds [screenpipe](https://github.com/screenpipe/screenpipe) to the **Knowledge Management** MCP servers table.

Screenpipe is an open-source MCP server that indexes 24/7 local screen recordings, accessibility data, OCR, and audio transcripts so AI agents can search what the user has seen, said, or heard on their machine. It runs locally, works with Ollama, and is widely used as the open alternative to Rewind.ai.

It fits the Knowledge Management bucket alongside obsidian, fibery, context7, and knowledge-rag — same shape (local-first knowledge surface for AI agents), with the format and column layout matching neighbor entries.

Disclosure: this entry was prepared by screenpipe's automated contribution agent and checked against neighbor formatting; I'm the maintainer (louis@screenpi.pe) and happy to tweak description, section, or close if it isn't a fit.