### PR TITLE
Add kaitoInfra/twitterapi-io-mcp-server (Integrations & APIs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ MCP servers for web search, content access, and web automation.
 | 27 | **browser-use-mcp-server** | Browse the web, directly from Cursor etc. | TBD | [GitHub](https://github.com/kontext-security/browser-use-mcp-server) |
 | 28 | **openagent** | ⚡️next-generation personal AI assistant powered by LLM, RAG and agent loops, supporting computer-use, browser-use and coding agent, demo: https://demo.openagentai.org | TBD | [GitHub](https://github.com/the-open-agent/openagent) |
 | 29 | **Xquik MCP Server** | X/Twitter data extraction, account monitoring, webhooks, and API exploration via MCP | TBD | [GitHub](https://github.com/Xquik-dev/x-twitter-scraper) |
+| 30 | **kaitoInfra/twitterapi-io-mcp-server** | Twitter/X data API for AI agents via MCP — tweet search with full operators, profiles, threads, real-time WebSocket streaming, trending topics. Hosted endpoint mcp.twitterapi.io/mcp ([twitterapi.io](https://twitterapi.io)) | TBD | [GitHub](https://github.com/kaitoInfra/twitterapi-io-mcp-server) |
 
 ### Integrations & APIs
 


### PR DESCRIPTION
Adds **kaitoInfra/twitterapi-io-mcp-server** in the Integrations & APIs containerised MCP servers section.

- Repo: https://github.com/kaitoInfra/twitterapi-io-mcp-server (MIT)
- npm: `@kaitoinfra/twitterapi-io-mcp-server`
- Hosted endpoint: `https://mcp.twitterapi.io/mcp`
- MCP Registry: `io.github.kaitoInfra/twitterapi-io-mcp-server` (active since 2026-05-23)

Twitter / X data API for AI agents — 12 read-only tools: tweet search with full operators, profiles, followers, conversation threads, real-time WebSocket streaming, trending topics, engagement metrics. Hosted runtime, no local install required.

Placed alongside the existing Xquik MCP Server entry. Happy to revise row number or wording.
