### PR TITLE
Add BuyWhere MCP server to Integrations & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ MCP servers for accessing external services and APIs.
 | 2 | shopify | Manage Shopify e-commerce stores and products | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/shopify.md) |
 | 3 | **shopsavvy** | Complete product and pricing data solution - search products, compare prices, track history | TBD | [GitHub](https://github.com/shopsavvy/shopsavvy-mcp-server) |
 | 4 | **agent-signal** | Collective intelligence for AI shopping agents - 23 tools for buyer intelligence, seller analytics, price alerts, and trend tracking | TBD | [GitHub](https://github.com/dan24ou-cpu/agent-signal) |
+| 5 | **buywhere-mcp** | Real-time product search and price comparison across Singapore and SEA merchants (Lazada, Shopee, FairPrice, etc.) | 2,000+ weekly npm downloads | [GitHub](https://github.com/BuyWhere/buywhere-mcp) |
 | 5 | atlassian | Integrate with Atlassian products like Jira and Confluence | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/atlassian.md) |
 | 5 | azure | Interact with Microsoft Azure cloud services and resources | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/azure.md) |
 | 6 | google-maps | Geographic information and location services | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/google-maps.md) |


### PR DESCRIPTION
## Add BuyWhere MCP server

Adds [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) to the Integrations & APIs section.

**What it does:** Real-time product search and price comparison across Singapore and Southeast Asia merchants (Lazada, Shopee, FairPrice, Cold Storage, Courts, etc.)

- npm: 2,000+ weekly downloads
- 11M+ products across 15+ merchants
- Works with Claude Desktop, Cursor, VS Code
- Open source (MIT)
- Hosted remote MCP endpoint: https://mcp.buywhere.ai/mcp

**Why it fits:** BuyWhere is a containerised MCP server for e-commerce product search, fitting naturally alongside Shopify and Shopsavvy in the Integrations & APIs section.