### PR TITLE
Add MCP Config Doctor fixtures to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ MCP servers for AI and machine learning capabilities.
 | 2 | [wong2/mcp-cli](https://github.com/wong2/mcp-cli) | Multiple | Command line inspector for testing |
 | 3 | [mclenhard/mcp-evals](https://github.com/mclenhard/mcp-evals) | Multiple | Package for running evaluations |
 | 4 | [Typewise/mcp-chaos-rig](https://github.com/Typewise/mcp-chaos-rig) | TypeScript | Fault injection server for testing MCP clients against auth failures, disappearing tools, flaky responses, and token expiry |
+| 5 | [MCP Config Doctor fixtures](https://github.com/supoju/mcp-config-doctor-fixtures) | Config fixtures | Redaction-safe Codex, Gemini CLI, and VS Code MCP client fixtures for validator tests and bug reports |
 
 ### Utilities
 


### PR DESCRIPTION
## Summary

Adds the public [MCP Config Doctor fixtures](https://github.com/supoju/mcp-config-doctor-fixtures) repository to **Testing Tools**.

The repository contains small, synthetic Codex, Gemini CLI, and VS Code MCP client configuration examples for validator tests, documentation, and reproducible bug reports. It includes no real credentials or machine-specific paths.

Disclosure: I maintain this fixture set as a companion to [MCP Config Doctor](https://mcpconfigdoctor.online/) and am submitting it transparently. The entry is descriptive rather than promotional.

## Checks

- Repository and linked site return HTTP 200.
- JSON fixtures parse successfully; the TOML fixture parses with Python `tomllib`.
- `git diff --check` passes.
