### PR TITLE
Add AI Applyd MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ There are currently 109 MCP servers available:
 | 4 | youtube_transcript | YouTube video transcript extraction | TBD | [GitHub](https://github.com/docker/labs-ai-tools-for-devs/blob/main/prompts/mcp/youtube_transcript.md) |
 | 5 | speech-ai | Speech AI with pronunciation assessment, text-to-speech, and speech-to-text | TBD | [GitHub](https://github.com/fasuizu-br/speech-ai-examples) |
 | 6 | **Prompt to Asset** | MCP server that generates production-ready visual assets (app icons, favicons, OG images) across 30+ image generation models | TBD | [GitHub](https://github.com/MohamedAbdallah-14/prompt-to-asset) |
+| 7 | **AI Applyd** | ATS resume scoring, job-description analysis, interview prep, cover letters, resume building and auto-apply that submits on the employer's own hiring system | TBD | [GitHub](https://github.com/whateverneveranywhere/aiapplyd-mcp) |
 
 
 


### PR DESCRIPTION
Adds **AI Applyd**, a hosted remote MCP server for job seekers.

- Repo: https://github.com/whateverneveranywhere/aiapplyd-mcp
- Endpoint: `https://mcp.aiapplyd.com/mcp` (Streamable HTTP, OAuth 2.1 + dynamic client registration)
- Listed on the official MCP Registry as `io.github.whateverneveranywhere/aiapplyd` and on Smithery

Tools cover ATS resume scoring, job-description analysis, interview prep, cover letters, resume building and auto-apply. Every tool declares `readOnlyHint`/`destructiveHint`. Nothing to install: it is a remote server, so clients connect by URL.

Formatted to match the existing entries in this list.