### PR TITLE
Add YouTube Transcript MCP to Multimedia & Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ There are currently 109 MCP servers available:
 | 5 | speech-ai | Speech AI with pronunciation assessment, text-to-speech, and speech-to-text | TBD | [GitHub](https://github.com/fasuizu-br/speech-ai-examples) |
 | 6 | **Prompt to Asset** | MCP server that generates production-ready visual assets (app icons, favicons, OG images) across 30+ image generation models | TBD | [GitHub](https://github.com/MohamedAbdallah-14/prompt-to-asset) |
 | 7 | **AI Applyd** | ATS resume scoring, job-description analysis, interview prep, cover letters, resume building and auto-apply that submits on the employer's own hiring system | TBD | [GitHub](https://github.com/whateverneveranywhere/aiapplyd-mcp) |
+| 8 | **YouTube Transcript MCP** | MCP server for YouTube transcripts, video and channel search, channel browsing, and playlist extraction, returned as clean JSON or markdown for Claude, ChatGPT and other MCP clients | TBD | [GitHub](https://github.com/ZeroPointRepo/youtube-mcp) |
 
 
 


### PR DESCRIPTION
### What this adds

One row to the **Multimedia & Design** table under Docker MCP Toolkit:

`| 8 | **YouTube Transcript MCP** | MCP server for YouTube transcripts, video and channel search, channel browsing, and playlist extraction, returned as clean JSON or markdown for Claude, ChatGPT and other MCP clients | TBD | [GitHub](https://github.com/ZeroPointRepo/youtube-mcp) |`

### What it is

[ZeroPointRepo/youtube-mcp](https://github.com/ZeroPointRepo/youtube-mcp) is an MIT-licensed, open source MCP server for YouTube content. Six tools: `get_youtube_transcript`, `search_youtube`, `get_channel_latest_videos`, `search_channel_videos`, `list_channel_videos`, `list_playlist_videos`. Works with Claude, ChatGPT, OpenClaw, Hermes Agent and other MCP clients, over Bearer token or OAuth 2.1 with Dynamic Client Registration.

It sits next to the existing `youtube_transcript` row (#4), which covers transcript extraction only, and adds video and channel search, channel browsing and playlist extraction.

### Disclosure

I maintain this repo. The linked repository is free and MIT licensed. Happy to reword or drop the row if it is not a fit.

### Checklist

- One line added, no other changes
- Row copied byte for byte from the existing table format
- Entry is not already listed anywhere in the README
