### PR TITLE
Add SandBase CLI to MCP utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ MCP servers for AI and machine learning capabilities.
 | 4 | f/MCPTools | Go | CLI tool for MCP server interactions |
 | 5 | portel-dev/ncp | TypeScript | MCP orchestrator with intelligent discovery, 98.2% accuracy, and 94.8% token savings. Transforms 100+ tools into 2 unified interfaces. [GitHub](https://github.com/portel-dev/ncp) |
 | 6 | strowk/mcp-autotest | Go | YAML-based autotest tool |
+| 7 | [sandbaseai/cli](https://github.com/sandbaseai/cli) | TypeScript | CLI for installing, authenticating, diagnosing, and safely rolling back SandBase MCP connections across 17+ AI clients. |
 
 ### Hosting Solutions
 


### PR DESCRIPTION
## Summary

Adds [SandBase CLI](https://github.com/sandbaseai/cli) to **MCP Toolkits → Utilities**.

SandBase CLI is an Apache-2.0 TypeScript CLI that installs and manages a hosted MCP gateway connection across 17+ AI clients. It supports OAuth, diagnostics, ownership-aware updates, and exact rollback.

## Why this category

The project manages client-side MCP configuration and connection lifecycle; it is not presented as an MCP server.

## Validation

- One README table row only
- `git diff --check` passes
- Canonical repository link used