### PR TITLE
Add MCP Lens to MCP Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ MCP servers for AI and machine learning capabilities.
 | 4 | f/MCPTools | Go | CLI tool for MCP server interactions |
 | 5 | portel-dev/ncp | TypeScript | MCP orchestrator with intelligent discovery, 98.2% accuracy, and 94.8% token savings. Transforms 100+ tools into 2 unified interfaces. [GitHub](https://github.com/portel-dev/ncp) |
 | 6 | strowk/mcp-autotest | Go | YAML-based autotest tool |
+| 7 | [MCP Lens](https://github.com/labmimors/dsh-mcp-lens) | TypeScript | DeepSeek Harness plugin that exposes configured MCP catalogs through two model-facing interfaces with allow/deny policy gates and lazy connections |
 
 ### Hosting Solutions
 


### PR DESCRIPTION
## Summary

Adds MCP Lens to **MCP Toolkits → Utilities**.

MCP Lens is a TypeScript plugin for DeepSeek Harness that exposes configured MCP catalogs through two model-facing interfaces, with allow/deny policy gates and lazy connections.

Disclosure: I maintain `labmimors/dsh-mcp-lens`. The entry is intentionally limited to a neutral description of its mechanism.

## Validation

- Confirmed there was no existing MCP Lens entry, issue, or pull request in this repository.
- Confirmed the linked repository returns HTTP 200.
- `git diff --check` passes.
- Verified the Utilities Markdown table keeps the expected column count.
