### PR TITLE
Add apistatuscheck-mcp-server to Integrations & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ MCP servers for accessing external services and APIs.
 | 23 | **Sanka MCP Server** | Hosted remote MCP server for Sanka API, connecting AI agents to CRM and back-office workflows. | TBD | [GitHub](https://github.com/sankaHQ/sanka-mcp) |
 | 24 | **mcp-notion-server** | A Model Context Protocol server for connecting Notion to MCP-compatible clients | TBD | [GitHub](https://github.com/suekou/mcp-notion-server) |
 | 25 | **dpx-mcp** | Settlement protocol MCP server for institutional cross-border USDC transactions on Base mainnet. 14 tools: Stability Oracle (macro, FX, ESG, climate, supply chain, earth systems), ESG scoring, FX quotes, Verification of Payee, and settlement execution. x402 pay-per-call. MiCA-aligned. | TBD | [GitHub](https://github.com/untitledfinancial/dpx-mcp) |
+| 26 | **apistatuscheck-mcp-server** | Live and historical availability for 285 public APIs and developer platforms across 29 categories — tell a third-party outage apart from a bug in your own code. 8 tools: status, uptime history, incident history, reliability ranking. Hosted Streamable HTTP, no API key. | TBD | [GitHub](https://github.com/shibley/apistatuscheck-mcp-server) |
 
 ### AI & Machine Learning
 


### PR DESCRIPTION
Adds one row to **Integrations & APIs**: a hosted MCP server that answers "is this third-party API actually down, or is it my code?"

**What it does** — 8 tools over live and historical availability for **285 public APIs** across **29 categories**: `list_apis`, `search_apis`, `get_api_status`, `list_down_apis`, `get_uptime_history`, `get_incident_history`, `rank_reliability`, `list_categories`.

**Reproduce the claims** (no key, no signup):

```bash
curl -s -X POST https://apistatuscheck.com/api/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools | length'
# => 8

curl -s https://apistatuscheck.com/api/status | jq '{count, categories: (.categories|length)}'
# => { "count": 285, "categories": 29 }
```

**Disclosures, up front so you don't have to find them:**

- This is a **self-submission** — I maintain it.
- **Docker Hub Pulls is `TBD`** because there is no image. It is a hosted Streamable HTTP endpoint (`https://apistatuscheck.com/api/mcp`), not a container. I've followed the existing convention of other hosted entries in this section (`Sanka MCP Server`, `TWZRD Agent Intel`, `x402engine-mcp`) rather than inventing a number. Happy to remove the row if you want this section limited to containerised servers only.
- The linked repo is the **server's registry metadata and install docs**, not the implementation — same shape as the hosted entries above.
- Freshness caveat, stated plainly: `list_apis` / `list_down_apis` read from an **hourly** monitor and every result carries its timestamp. `get_api_status` probes at call time. The server's own `instructions` string says this, so an agent reading it is not misled.

Row placed at the end of the numbered table as #26. No other lines touched.
