### PR TITLE
 Add KyttoMCP to MCP Clients → Desktop Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ MCP servers for AI and machine learning capabilities.
 | 5 | **[MetaMCP](https://github.com/metatool-ai/metatool-app)** | Unified middleware MCP client | Windows, macOS, Linux |
 | 6 | **[Continue.dev](https://github.com/continuedev/continue)** | AI coding assistant for IDEs | VS Code, JetBrains |
 | 7 | **[MCPlato](https://mcplato.com/)** | Local-first desktop AI workspace with workspace-scoped MCP configuration and permission-aware tool use | Windows, macOS |
-
+| 8 | **[KyttoMCP](https://kytto.jakubhecht.sk/)** | Local control panel that manages MCP server configuration across Claude Desktop, Claude
+  Code, Cursor, VS Code and Codex from one matrix | Windows, macOS |
 
 ### Mobile Applications
 


### PR DESCRIPTION
Adds KyttoMCP as entry #8 under MCP Clients → Desktop Applications.
  
  KyttoMCP is a local desktop app that reads the MCP configuration files for                             
  Claude Desktop, Claude Code, Cursor, VS Code and Codex and shows every server
  against every client in one matrix. It also runs real MCP handshakes for health
  checks, estimates per-server context cost, and makes a timestamped backup before
  every write.
  
  It is not an MCP server and not a registry — it manages the client-side
  configuration of servers you already run. Free beta for macOS and Windows; the
  app is closed source, and the linked repository holds the releases, changelog
  and issue tracker rather than the source.
  
  Site: https://kytto.jakubhecht.sk/
  Repo: https://github.com/heyitsjakub/KyttoMCP
  Demo: 72-second recording at https://kytto.jakubhecht.sk/#demo

  Followed the existing row format and appended to the end of the table.