### PR TITLE
Add Agent QA to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ MCP servers for AI and machine learning capabilities.
 | 3 | [mclenhard/mcp-evals](https://github.com/mclenhard/mcp-evals) | Multiple | Package for running evaluations |
 | 4 | [Typewise/mcp-chaos-rig](https://github.com/Typewise/mcp-chaos-rig) | TypeScript | Fault injection server for testing MCP clients against auth failures, disappearing tools, flaky responses, and token expiry |
 | 5 | [MCP Config Doctor fixtures](https://github.com/supoju/mcp-config-doctor-fixtures) | Config fixtures | Redaction-safe Codex, Gemini CLI, and VS Code MCP client fixtures for validator tests and bug reports |
+| 6 | [Agent QA](https://github.com/vostride/agent-qa) | TypeScript | Local stdio MCP server for natural-language web and mobile regression tests with retained execution evidence |
 
 ### Utilities
 


### PR DESCRIPTION
## Summary

Adds Agent QA to the **Testing Tools** table.

Agent QA exposes a local stdio MCP server for running natural-language web and mobile regression tests and inspecting retained execution evidence. The entry uses the table's existing name, link, language, and factual-description format.

## Validation

- Confirmed the canonical repository URL resolves.
- Confirmed Agent QA and its canonical URL were absent from the catalog and existing issues/PRs before editing.
- Confirmed every Testing Tools row retains the same four-column Markdown shape.
- Ran `git diff --check`.

## Disclosure and license

I’m affiliated with Vostride, the team developing Agent QA.

Agent QA is source-available under FSL-1.1-ALv2; each release converts to Apache-2.0 after two years. Agent QA has no software fee for permitted use, though configured model, browser, or device providers may charge separately.
