### PR TITLE
docs: add SandBase Harness to DevOps infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ MCP servers for managing infrastructure, containers, and DevOps workflows.
 | 35 | **awesome-devops-mcp-servers** | A curated list of awesome MCP servers focused on DevOps tools and capabilities. | TBD | [GitHub](https://github.com/rohitg00/awesome-devops-mcp-servers) |
 | 36 | **KiCAD-MCP-Server** | KiCAD MCP is a Model Context Protocol (MCP) implementation that enables Large Language Models (LLMs) like Claude to directly interact with KiCAD for printed circuit board design. | TBD | [GitHub](https://github.com/mixelpixx/KiCAD-MCP-Server) |
 | 37 | **Find MCP** | Search 17,000+ MCP servers from the official MCP registry - remote Streamable HTTP (catalog.agentage.io/mcp, no auth for search) or stdio (npx @agentage/find-mcp) | TBD | [GitHub](https://github.com/agentage/find-mcp) |
+| 38 | **SandBase Harness** | Local-first MCP bridge and agent runtime for governed sessions, approvals, credentials, audit/replay, and sandboxed execution through local, Docker, Kubernetes, or self-hosted worker backends | TBD | [GitHub](https://github.com/sandbaseai/sandbase-harness) |
 
 ### Database & Storage
 


### PR DESCRIPTION
## Summary\n- add SandBase Harness to DevOps & Infrastructure\n- describe the local-first MCP bridge, governed sessions, approvals, credentials, audit/replay, and selectable execution backends\n\n## Verification\n-  passes\n- Project: https://github.com/sandbaseai/sandbase-harness\n- Installation: https://github.com/sandbaseai/sandbase-harness/blob/main/README.md#installation\n- MCP setup: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/mcp.md\n- Sandbox backends: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/sandboxing.md\n- Latest release: https://github.com/sandbaseai/sandbase-harness/releases/latest\n\nThe entry is factual and does not claim universal isolation or security certification.