### PR TITLE
Add ParlayAPI source-build MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ MCP servers for accessing external services and APIs.
 | 23 | **Sanka MCP Server** | Hosted remote MCP server for Sanka API, connecting AI agents to CRM and back-office workflows. | TBD | [GitHub](https://github.com/sankaHQ/sanka-mcp) |
 | 24 | **mcp-notion-server** | A Model Context Protocol server for connecting Notion to MCP-compatible clients | TBD | [GitHub](https://github.com/suekou/mcp-notion-server) |
 | 25 | **dpx-mcp** | Settlement protocol MCP server for institutional cross-border USDC transactions on Base mainnet. 14 tools: Stability Oracle (macro, FX, ESG, climate, supply chain, earth systems), ESG scoring, FX quotes, Verification of Payee, and settlement execution. x402 pay-per-call. MiCA-aligned. | TBD | [GitHub](https://github.com/untitledfinancial/dpx-mcp) |
+| 26 | **ParlayAPI** | Sports odds and player props with your own API key and account allowances; build from the repository Dockerfile | N/A (source build) | [GitHub](https://github.com/JacobiusMakes/parlay-api-mcp) |
 
 ### AI & Machine Learning
 


### PR DESCRIPTION
Adds ParlayAPI to Integrations & APIs. It exposes sports odds and player props using each user's own API key and account allowances.

This is explicitly a source-build entry, with Docker Hub pulls marked N/A. It does not claim Docker Toolkit/catalog acceptance. The public source includes a Dockerfile; hosted Docker validation, build, and discovery checks passed: https://github.com/JacobiusMakes/parlay-api-mcp/actions/runs/33986160635.

Checked source and open/closed PRs for duplicates; README table formatting and `git diff --check` pass. The README welcomes PRs, although its linked CONTRIBUTING.md is currently absent.
