### PR TITLE
Add FLUJO to web MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ MCP servers for AI and machine learning capabilities.
 | 2 | [Glama AI](https://glama.ai) | Web-based multi-model client with MCP | Web |
 | 3 | [Phind](https://www.phind.com) | Developer-focused search with MCP | Web |
 | 4 | [Ontheia](https://ontheia.ai) | Self-hosted, open-source AI agent platform with native MCP support. Multi-provider, GDPR by design. | Web, Linux, MacOS, Windows |
+| 5 | [FLUJO](https://github.com/mario-andreschak/FLUJO) | Local-first visual AI agent builder and MCP client with server management, tool inspection, multi-model chat, and Docker deployment | Web, Windows, macOS, Linux |
 
 ## MCP Toolkits
 


### PR DESCRIPTION
Adds FLUJO to the Web Applications client table. It is an MIT-licensed, local-first visual AI agent builder with local/remote MCP server management, tool inspection, multi-model chat, and workflow debugging.

FLUJO supports container deployment with the [documented Docker image and Dockerfile](https://github.com/mario-andreschak/FLUJO#run-with-docker), so it also fits the collection's container focus. [MCP client source](https://github.com/mario-andreschak/FLUJO/tree/main/src/backend/services/mcp).

Checked the current list and prior submissions for duplicates; followed the existing numbered table format; `git diff --check` passed.