### PR TITLE
Add mcp-office-suite to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ There are currently 110 MCP servers available:
 | 20 | **server** | Core PHP implementation for the Model Context Protocol (MCP) server | [GitHub](https://github.com/php-mcp/server) |
 | 21 | **gadgethumans-api-hub-mcp** | 334 free developer tools: QR codes, passwords, UUIDs, hashes, Base64, JSON, color converter, email verification, IP geolocation, timestamps, plus 300+ calculators, text analysis, color tools, readability, domain, code and financial tools. MCP server at `uvx gadgethumans-api-hub-mcp`. Free, no API key required. | [GitHub](https://github.com/scotia1973-bot/gadgethumans-api-hub-mcp) |
 | 22 | **mcp-server** | MCP Server for Burp | [GitHub](https://github.com/PortSwigger/mcp-server) |
+| 23 | **mcp-office-suite** | One MCP server for a whole freelance back office: proxies 31 sibling servers (invoicing, quotes, time tracking, expenses, bank-statement reconciliation, spreadsheets, PDF, DOCX, kanban) behind a single config entry. Runs locally, data stays in JSON on disk, Dockerfile in the repo root. | [GitHub](https://github.com/theluckystrike/mcp-office-suite) |
 
 ### Communication
 


### PR DESCRIPTION
Adds one row (#23) to **Containerised MCP Servers → Development Tools**, matching the existing table format exactly. No other lines touched.

**[theluckystrike/mcp-office-suite](https://github.com/theluckystrike/mcp-office-suite)** — one MCP server for a whole freelance back office. It proxies 31 sibling servers (invoicing, quotes, time tracking, expenses, bank-statement reconciliation, spreadsheets, PDF, DOCX, kanban) behind a single config entry, so a client gets all of them from one `mcpServers` block instead of 31.

Fits this list specifically because it is containerised: there is a `Dockerfile` at the repo root, and each of the 31 siblings has its own public mirror repo with its own `Dockerfile` too.

- MIT, open source, actively maintained (release v0.21.0 today)
- Runs entirely locally over stdio; data stays in JSON files on the user's machine
- Also published to the official MCP registry under `io.github.theluckystrike/*`
- Monorepo: https://github.com/theluckystrike/mcp-servers

Thanks for maintaining the list.