### PR TITLE
Add Cohesivity to DevOps and infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ MCP servers for managing infrastructure, containers, and DevOps workflows.
 | 50 | **matlab-mcp-server** | Run MATLAB® using AI applications with the official MATLAB MCP Server from MathWorks®. This MCP server for MATLAB supports a wide range of coding agents like Claude Code® and Visual Studio® Code. | [GitHub](https://github.com/matlab/matlab-mcp-server) |
 | 51 | **cve-mcp-server** | Production-grade MCP server giving Claude 27 security intelligence tools across 21 APIs — CVE lookup, EPSS scoring, CISA KEV, MITRE ATT&CK, Shodan, VirusTotal, and more. | [GitHub](https://github.com/mukul975/cve-mcp-server) |
 
+| 52 | **Cohesivity** | cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402. | [GitHub](https://github.com/cohesivity-org/cohesivity-plugin) |
+
 ### Database & Storage
 
 MCP servers for accessing and managing databases and storage solutions.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ MCP servers for managing infrastructure, containers, and DevOps workflows.
 | 49 | **arc-kit** | The Enterprise Architecture Governance Harness — strategy, architecture, delivery, and assurance using AI coding assistants | [GitHub](https://github.com/tractorjuice/arc-kit) |
 | 50 | **matlab-mcp-server** | Run MATLAB® using AI applications with the official MATLAB MCP Server from MathWorks®. This MCP server for MATLAB supports a wide range of coding agents like Claude Code® and Visual Studio® Code. | [GitHub](https://github.com/matlab/matlab-mcp-server) |
 | 51 | **cve-mcp-server** | Production-grade MCP server giving Claude 27 security intelligence tools across 21 APIs — CVE lookup, EPSS scoring, CISA KEV, MITRE ATT&CK, Shodan, VirusTotal, and more. | [GitHub](https://github.com/mukul975/cve-mcp-server) |
-
 | 52 | **Cohesivity** | cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402. | [GitHub](https://github.com/cohesivity-org/cohesivity-plugin) |
 
 ### Database & Storage


### PR DESCRIPTION
Adds one row to DevOps & Infrastructure, preserving the four-column table and existing row numbering.

cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402.

The public source contains a local stdio MCP for project provisioning and an OAuth-protected remote management MCP. The same repository documents plugin and skill installation, so this uses one project entry rather than three duplicate rows.

Reviewed merged SandBase Harness PR #105 and the current remote/stdio Find MCP entry. This is a source listing, not a claim that Cohesivity has a Docker Hub image or has been accepted into Docker's MCP Catalog.

The README links CONTRIBUTING.md, but that file is absent from the current tree. I followed the current table format and merged submission pattern. Checked source links, duplicate entries/PRs, exact description, consecutive row numbers and four-column structure, and `git diff --check`.

I maintain Cohesivity.
